### PR TITLE
Avoid waiting

### DIFF
--- a/src/main/java/com/zebrunner/carina/webdriver/decorator/ExtendedWebElement.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/decorator/ExtendedWebElement.java
@@ -671,6 +671,13 @@ public class ExtendedWebElement implements IWebElement, WebElement, IExtendedWeb
     }
 
     /**
+     * Click on an element with no wait
+     */
+    public void clickNoWait() {
+        doAction(ACTION_NAME.CLICK, Duration.ofSeconds(0), null);
+    }
+
+    /**
      * Click on element
      *
      * @param timeout timeout, in seconds

--- a/src/main/java/com/zebrunner/carina/webdriver/decorator/ExtendedWebElement.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/decorator/ExtendedWebElement.java
@@ -1411,11 +1411,15 @@ public class ExtendedWebElement implements IWebElement, WebElement, IExtendedWeb
             Object... inputArgs) {
         clearElementState();
 
-        if (waitCondition != null) {
-            // do verification only if waitCondition is not null
-            if (!waitUntil(waitCondition, timeout)) {
-                // TODO: think about raising exception otherwise we do extra call and might wait and hangs especially for mobile/appium
-                LOGGER.error(Messager.ELEMENT_CONDITION_NOT_VERIFIED.getMessage(actionName.getKey(), getNameWithLocator()));
+        try {
+            this.element = findElement();
+        } catch (StaleElementReferenceException | NoSuchElementException e) {
+            if (waitCondition != null) {
+                // do verification only if waitCondition is not null
+                if (!waitUntil(waitCondition, timeout)) {
+                    // TODO: think about raising exception otherwise we do extra call and might wait and hangs especially for mobile/appium
+                    LOGGER.error(Messager.ELEMENT_CONDITION_NOT_VERIFIED.getMessage(actionName.getKey(), getNameWithLocator()));
+                }
             }
         }
 
@@ -1427,7 +1431,8 @@ public class ExtendedWebElement implements IWebElement, WebElement, IExtendedWeb
         Object output = null;
 
         try {
-            this.element = findElement();
+            if (this.element == null)
+                this.element = findElement();
             output = overrideAction(actionName, inputArgs);
         } catch (StaleElementReferenceException e) {
             // TODO: analyze mobile testing for staled elements. Potentially it should be fixed by appium java client already

--- a/src/main/java/com/zebrunner/carina/webdriver/decorator/ExtendedWebElement.java
+++ b/src/main/java/com/zebrunner/carina/webdriver/decorator/ExtendedWebElement.java
@@ -1419,6 +1419,9 @@ public class ExtendedWebElement implements IWebElement, WebElement, IExtendedWeb
         clearElementState();
 
         try {
+            // this turns out to be a bad idea.
+            //   Someone passed in a waitCondition, we must honor it.
+            //   If someone wants to pass in a null waitCondition, they can do that
             this.element = findElement();
         } catch (StaleElementReferenceException | NoSuchElementException e) {
             if (waitCondition != null) {


### PR DESCRIPTION
I think it's better to
**First try to find the element
If we fail, then wait, then find**

than
**First wait for the object to exist, then find**

The only issue I see with this is if the wait condition is waiting for a different element, for example wait for ButtonA to be visible, then click ButtonB, but I don't think this is done in the Carina library